### PR TITLE
Increase FAILED_REQUEST_MAX_RETRIES from 3 to 6

### DIFF
--- a/cyhy_commander/jobs/vulnscan.py
+++ b/cyhy_commander/jobs/vulnscan.py
@@ -49,7 +49,7 @@ WAIT_TIME_SEC = 10
 # Would be nice to get this working
 VERIFY_SSL = False
 # Number of times to retry a failed request before giving up
-FAILED_REQUEST_MAX_RETRIES = 3
+FAILED_REQUEST_MAX_RETRIES = 6
 # Seconds to wait between failed request retries
 FAILED_REQUEST_RETRY_WAIT_SEC = 30
 


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR increases `FAILED_REQUEST_MAX_RETRIES` from 3 to 6.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This gives the script enough wait time to continue without failing when the Nessus API becomes unavailable for ~2 minutes every day after downloading its newest plugins (as long as we keep `FAILED_REQUEST_RETRY_WAIT_SEC` set to 30 seconds).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was deployed in Production for testing and I was able to confirm that there are no longer a large number of script failures at the same time as the daily plugin download.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

