### PR TITLE
Handle the latest Nmap's XML output

### DIFF
--- a/cyhy_commander/nmap/__init__.py
+++ b/cyhy_commander/nmap/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["NmapImporter", "NmapContentHander"]
+__all__ = ["NmapImporter", "NmapContentHandler"]
 
-from nmap_handler import NmapContentHander
+from nmap_handler import NmapContentHandler
 from nmap_importer import NmapImporter

--- a/cyhy_commander/nmap/nmap_handler.py
+++ b/cyhy_commander/nmap/nmap_handler.py
@@ -5,7 +5,7 @@ import netaddr
 from cyhy.util import copy_attrs
 
 
-class NmapContentHander(ContentHandler):
+class NmapContentHandler(ContentHandler):
     def __init__(self, host_callback, end_callback):
         ContentHandler.__init__(self)
         self.host_callback = host_callback

--- a/cyhy_commander/nmap/nmap_handler.py
+++ b/cyhy_commander/nmap/nmap_handler.py
@@ -67,14 +67,14 @@ class NmapContentHandler(ContentHandler):
             copy_attrs(attrs, service, ["servicefp"])
         elif (
             name == "osmatch"
-            and self.xmloutputversion == "1.04"
+            and self.xmloutputversion in ["1.04", "1.05"]
             and not self.first_osmatch_done_for_host
         ):
             os = self.currentHost["os"] = {"classes": []}
             copy_attrs(attrs, os)
         elif (
             name == "osclass"
-            and self.xmloutputversion == "1.04"
+            and self.xmloutputversion in ["1.04", "1.05"]
             and not self.first_osmatch_done_for_host
         ):
             clazz = {}

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -11,7 +11,7 @@ import netaddr
 from cyhy.core import STAGE, UNKNOWN_OWNER
 from cyhy.db import CHDatabase, IPPortTicketManager, IPTicketManager
 from cyhy.util import util
-from nmap_handler import NmapContentHander
+from nmap_handler import NmapContentHandler
 
 RISKY_SERVICES_SOURCE_ID = 1  # Identifier for "risky service" tickets
 # Pulled from https://svn.nmap.org/nmap/nmap-services
@@ -53,12 +53,12 @@ class NmapImporter(object):
     def __init__(self, db, stage=STAGE.PORTSCAN):
         self.__logger = logging.getLogger(__name__)
         if stage in (STAGE.NETSCAN1, STAGE.NETSCAN2):
-            self.handler = NmapContentHander(
+            self.handler = NmapContentHandler(
                 self.__netscan_host_callback, self.__end_callback
             )
             self.__ticket_manager = IPTicketManager(db)
         elif stage == STAGE.PORTSCAN:
-            self.handler = NmapContentHander(
+            self.handler = NmapContentHandler(
                 self.__portscan_host_callback, self.__end_callback
             )
             self.__ticket_manager = IPPortTicketManager(
@@ -68,7 +68,7 @@ class NmapImporter(object):
                 1, 65536
             )  # A PORTSCAN is all ports.  Don't consider port 0 in scope.
         elif stage == STAGE.BASESCAN:
-            self.handler = NmapContentHander(
+            self.handler = NmapContentHandler(
                 self.__baseline_host_callback, self.__end_callback
             )
             self.__ticket_manager = None


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does two things:
- Fix a class name that is incorrect (but consistently so).
- Handle the XML output from the latest version of Nmap.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There are some checks in the Nmap output handler that check for a specific XML output version. The latest Nmap release we use (7.93) outputs a newer XML version, but the content is otherwise still parse-able. Thus the check is changed from checking for a specific version to checking against a list of acceptable versions.

The `NmapContentHander` class is a missed typo from what I can see and it is thus updated to the more correct `NmapContentHandler`.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that the change in logic functions successfully. When processing the results of `PORTSCAN` jobs the commander no longer throws a `'NoneType' object has no attribute 'has_key'` exception.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
