### PR TITLE
Sleep before connecting to the Nessus Controller in the `vulnscan.py` job

### DIFF
--- a/cyhy_commander/jobs/vulnscan.py
+++ b/cyhy_commander/jobs/vulnscan.py
@@ -343,10 +343,10 @@ def main():
     LOGGER.info("Using ports file: %s", ports_file)
 
     # read in targets and ports
-    with open(targets_file, "r") as f:
+    with open(targets_file) as f:
         targets = f.readlines()
 
-    with open(ports_file, "r") as f:
+    with open(ports_file) as f:
         ports = f.readline().strip()
 
     # Before beginning work that involves the Nessus Controller we will sleep for a

--- a/cyhy_commander/jobs/vulnscan.py
+++ b/cyhy_commander/jobs/vulnscan.py
@@ -5,6 +5,7 @@ import copy
 import glob
 import json
 import logging
+import secrets
 import sys
 import time
 
@@ -50,6 +51,10 @@ VERIFY_SSL = False
 FAILED_REQUEST_MAX_RETRIES = 6
 # Seconds to wait between failed request retries
 FAILED_REQUEST_RETRY_WAIT_SEC = 30
+
+# The maximum amount of time in seconds to sleep before connecting to the Nessus
+# Controller.
+MAX_SLEEP_SEC = 30
 
 if DEBUG:
     # Standard Python Libraries
@@ -343,6 +348,11 @@ def main():
 
     with open(ports_file, "r") as f:
         ports = f.readline().strip()
+
+    # Before beginning work that involves the Nessus Controller we will sleep for a
+    # random amount of time (range of [0, MAX_SLEEP_SEC+1) seconds) to help prevent
+    # Nessus from getting overloaded by multiple jobs starting at the same time.
+    time.sleep(secrets.randbelow(MAX_SLEEP_SEC + 1))
 
     try:
         LOGGER.info("Instantiating Nessus controller at: %s", api_configuration["url"])


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a sleep to the `vulnscan.py` job that occurs before communication with the Nessus Controller begins. It is random across the range of [0, 31) seconds as currently configured. and should help prevent Nessus from being slammed when multiple jobs are pushed at once.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We noticed very spiky CPU usage on `vulnscan` instances in our production environment. They likely align with commander cycles pushing new jobs and the initial load on Nessus when that happens. I floated the idea of a random delay for each job to help flatten the spikes of activity and here we are.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that the Python code added works as expected. I will test in production when team consensus on the change is reached.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
