### PR TITLE
Process retrieved jobs using a thread pool

### DIFF
--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -473,7 +473,7 @@ class Commander(object):
                         self.__logger.critical(traceback.format_exc())
                 else:
                     # sleep if both queues are empty
-                    time.sleep(10)
+                    time.sleep(1)
 
     def __process_successful_job(self, job_path):
         # Get the name of the current thread

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -29,6 +29,7 @@ import random
 import shutil
 import signal
 import sys
+import threading
 import time
 import traceback
 from ConfigParser import SafeConfigParser
@@ -90,6 +91,7 @@ DATABASE_URI = "database-uri"
 DEFAULT = "DEFAULT"
 DEFAULT_SCHEDULER = "default-scheduler"
 DEFAULT_SECTION = "default-section"
+JOB_PROCESSING_THREADS = "job-processing-threads"
 JOBS_PER_NESSUS_HOST = "jobs-per-nessus-host"
 JOBS_PER_NMAP_HOST = "jobs-per-nmap-host"
 KEEP_FAILURES = "keep-failures"
@@ -308,9 +310,9 @@ class Commander(object):
                     local_job_path = os.path.join(destDir, job)
 
                     if destDir == SUCCESS_DIR:
-                        self.__process_successful_job(local_job_path)
+                        self.__successful_job_queue.put(local_job_path)
                     else:
-                        self.__process_failed_job(local_job_path)
+                        self.__failed_job_queue.put(local_job_path)
 
                 else:
                     self.__logger.warning(
@@ -431,6 +433,24 @@ class Commander(object):
             execute(self.__push_job, self, job_path, hosts=[lowest_host])
             counts[lowest_host] += 1
 
+    def __process_queued_jobs(self):
+        # run as long as the commander is running
+        while self.__is_running:
+            try:
+                # check the successful jobs queue
+                job_path = self.__successful_job_queue.get()
+                self.__process_successful_job(job_path)
+                self.__successful_job_queue.task_done()
+            except Queue.Empty:
+                # check the failed jobs queue
+                try:
+                    job_path = self.__failed_job_queue.get()
+                    self.__process_failed_job(job_path)
+                    self.__failed_job_queue.task_done()
+                except Queue.Empty:
+                    # sleep if both queues are empty
+                    time.sleep(10)
+
     def __process_successful_job(self, job_path):
         for sink in self.__success_sinks:
             if sink.can_handle(job_path):
@@ -481,6 +501,7 @@ class Commander(object):
         config.set(None, DATABASE_URI, "mongodb://localhost:27017/")
         config.set(None, JOBS_PER_NMAP_HOST, "8")
         config.set(None, JOBS_PER_NESSUS_HOST, "8")
+        config.set(None, JOB_PROCESSING_THREADS, "4")
         config.set(None, POLL_INTERVAL, "30")
         config.set(None, NEXT_SCAN_LIMIT, "2000")
         config.set(None, DEFAULT_SECTION, TESTING_SECTION)
@@ -623,6 +644,20 @@ class Commander(object):
         self.__successful_job_queue = Queue.Queue()
         self.__failed_job_queue = Queue.Queue()
 
+        # spin up the thread pool to process retrieved work
+        job_processing_threads = []
+        job_processing_thread_count = config.getint(
+            config_section, JOB_PROCESSING_THREADS
+        )
+        for t in range(job_processing_thread_count):
+            try:
+                job_processing_thread = threading.Thread(
+                    target=self.__process_queued_jobs
+                )
+                job_processing_threads.append(job_processing_thread)
+                job_processing_thread.start()
+            except Exception:
+                self.__logger.error("Unable to start job processing thread #%s", t)
         # pairs of hosts and job sources
         work_groups = (
             (NMAP_WORKGROUP, nmap_hosts, self.__nmap_sources, jobs_per_nmap_host),
@@ -762,6 +797,11 @@ class Commander(object):
             except Exception, e:
                 self.__logger.critical(e)
                 self.__logger.critical(traceback.format_exc())
+
+        # wait for the job processing threads to exit
+        for job_processing_thread in job_processing_threads:
+            job_processing_thread.join()
+
         self.__logger.info("Shutting down.")
         disconnect_all()
 

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -718,7 +718,7 @@ class Commander(object):
                 self.__logger.error(e)
                 # bail out
                 self.__logger.critical(
-                    "Shutting down due to inability to start threads."
+                    "Shutting down due to inability to start job processing threads."
                 )
                 self.__is_running = False
 
@@ -730,7 +730,7 @@ class Commander(object):
             self.__logger.error("Unable to start job queue monitoring thread")
             self.__logger.error(e)
             # bail out
-            self.__logger.critical("Shutting down due to inability to start threads.")
+            self.__logger.critical("Shutting down due to inability to start queue monitoring thread.")
             self.__is_running = False
 
         # pairs of hosts and job sources

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -438,13 +438,13 @@ class Commander(object):
         while self.__is_running:
             try:
                 # check the successful jobs queue
-                job_path = self.__successful_job_queue.get()
+                job_path = self.__successful_job_queue.get(timeout=1)
                 self.__process_successful_job(job_path)
                 self.__successful_job_queue.task_done()
             except Queue.Empty:
                 # check the failed jobs queue
                 try:
-                    job_path = self.__failed_job_queue.get()
+                    job_path = self.__failed_job_queue.get(timeout=1)
                     self.__process_failed_job(job_path)
                     self.__failed_job_queue.task_done()
                 except Queue.Empty:

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -480,9 +480,9 @@ class Commander(object):
                 self.__logger.critical(traceback.format_exc())
 
             # report task completion no matter what so the queue can be joined
-            target_queue.task_done()
+            target_job_queue.task_done()
 
-            # return job processing duration
+            # return path of the job that was processed
             return job_path
 
         # run as long as the commander is processing jobs

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -434,6 +434,18 @@ class Commander(object):
             execute(self.__push_job, self, job_path, hosts=[lowest_host])
             counts[lowest_host] += 1
 
+    def __monitor_job_queues(self):
+        # output the approximate amount of work on each of the queues every 10 seconds
+        while self.__is_processing_jobs:
+            self.__logger.debug(
+                "%d jobs in the successful job queue"
+                % self.__successful_job_queue.qsize()
+            )
+            self.__logger.debug(
+                "%d jobs in the failed job queue" % self.__failed_job_queue.qsize()
+            )
+            sleep(10)
+
     def __process_queued_jobs(self):
         # run as long as the commander is processing jobs or the queues are not empty
         #
@@ -712,6 +724,19 @@ class Commander(object):
                 )
                 self.__is_running = False
 
+        # spin up a thread to output queue load information
+        try:
+            job_queue_monitor_thread = threading.Thread(
+                target=self.__monitor_job_queues
+            )
+            job_queue_monitor_thread.start()
+        except Exception as e:
+            self.__logger.error("Unable to start job queue monitoring thread")
+            self.__logger.error(e)
+            # bail out
+            self.__logger.critical("Shutting down due to inability to start threads")
+            self.__is_running = False
+
         # pairs of hosts and job sources
         work_groups = (
             (NMAP_WORKGROUP, nmap_hosts, self.__nmap_sources, jobs_per_nmap_host),
@@ -860,6 +885,9 @@ class Commander(object):
         # wait for the job processing threads to exit
         for job_processing_thread in job_processing_threads:
             job_processing_thread.join()
+
+        # wait for the job queue monitoring thread to exit
+        job_queue_monitor_thread.join()
 
         self.__logger.info("Shutting down.")
         disconnect_all()

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -440,18 +440,38 @@ class Commander(object):
             or not self.__successful_job_queue.empty()
             or not self.__failed_job_queue.empty()
         ):
+            job_path = None
+
+            # check the successful jobs queue
             try:
-                # check the successful jobs queue
                 job_path = self.__successful_job_queue.get(timeout=1)
-                self.__process_successful_job(job_path)
-                self.__successful_job_queue.task_done()
             except Queue.Empty:
+                pass
+
+            # process successful job
+            if job_path is not None:
+                try:
+                    self.__process_successful_job(job_path)
+                    self.__successful_job_queue.task_done()
+                except Exception, e:
+                    self.__logger.critical(e)
+                    self.__logger.critical(traceback.format_exc())
+            else:
                 # check the failed jobs queue
                 try:
                     job_path = self.__failed_job_queue.get(timeout=1)
-                    self.__process_failed_job(job_path)
-                    self.__failed_job_queue.task_done()
                 except Queue.Empty:
+                    pass
+
+                # process failed job
+                if job_path is not None:
+                    try:
+                        self.__process_failed_job(job_path)
+                        self.__failed_job_queue.task_done()
+                    except Exception, e:
+                        self.__logger.critical(e)
+                        self.__logger.critical(traceback.format_exc())
+                else:
                     # sleep if both queues are empty
                     time.sleep(10)
 

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -444,7 +444,7 @@ class Commander(object):
             self.__logger.debug(
                 "%d jobs in the failed job queue" % self.__failed_job_queue.qsize()
             )
-            sleep(10)
+            time.sleep(10)
 
     def __process_queued_jobs(self):
         # run as long as the commander is processing jobs or the queues are not empty

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -141,9 +141,8 @@ class Commander(object):
         self.__all_hosts_idle = False
         self.__config_section = config_section
         self.__db = None
-        self.__failure_sinks = []
-        self.__successful_job_queue = None
         self.__failed_job_queue = None
+        self.__failure_sinks = []
         self.__host_exceptions = defaultdict(lambda: 0)
         self.__hosts_on_cooldown = []
         self.__is_processing_jobs = True
@@ -156,6 +155,7 @@ class Commander(object):
         self.__setup_directories()
         self.__shutdown_when_idle = False
         self.__success_sinks = []
+        self.__successful_job_queue = None
         self.__test_mode = False
 
     def __setup_logging(self, debug_logging, console_logging):

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -730,7 +730,7 @@ class Commander(object):
             self.__logger.error("Unable to start job queue monitoring thread")
             self.__logger.error(e)
             # bail out
-            self.__logger.critical("Shutting down due to inability to start threads")
+            self.__logger.critical("Shutting down due to inability to start threads.")
             self.__is_running = False
 
         # pairs of hosts and job sources

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -24,6 +24,7 @@ Options:
 from collections import defaultdict
 import logging
 import os
+import Queue
 import random
 import shutil
 import signal
@@ -139,6 +140,8 @@ class Commander(object):
         self.__config_section = config_section
         self.__db = None
         self.__failure_sinks = []
+        self.__successful_job_queue = None
+        self.__failed_job_queue = None
         self.__host_exceptions = defaultdict(lambda: 0)
         self.__hosts_on_cooldown = []
         self.__is_running = True
@@ -617,6 +620,9 @@ class Commander(object):
         self.__setup_sources()
         self.__setup_sinks()
 
+        self.__successful_job_queue = Queue.Queue()
+        self.__failed_job_queue = Queue.Queue()
+
         # pairs of hosts and job sources
         work_groups = (
             (NMAP_WORKGROUP, nmap_hosts, self.__nmap_sources, jobs_per_nmap_host),
@@ -710,6 +716,10 @@ class Commander(object):
                     if hosts == None:
                         continue
                     execute(self.__done_jobs, self, hosts=hosts)
+
+                # wait for work to process
+                self.__successful_job_queue.join()
+                self.__failed_job_queue.join()
 
                 # check for scheduled hosts
                 self.__logger.debug(

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -154,6 +154,7 @@ class Commander(object):
         self.__nessus_sources = []
         self.__next_scan_limit = 2000
         self.__nmap_sources = []
+        self.__queue_monitor_output_lock = threading.Lock()
         self.__setup_directories()
         self.__shutdown_when_idle = False
         self.__success_sinks = []
@@ -439,14 +440,15 @@ class Commander(object):
     def __monitor_job_queues(self):
         # output the approximate amount of work on each of the queues every 10 seconds
         while self.__is_processing_jobs:
-            self.__logger.debug(
-                "%d unfinished jobs in the successful job queue"
-                % self.__successful_job_queue.unfinished_tasks
-            )
-            self.__logger.debug(
-                "%d unfinished jobs in the failed job queue"
-                % self.__failed_job_queue.unfinished_tasks
-            )
+            with self.__queue_monitor_output_lock:
+                self.__logger.debug(
+                    "%d unfinished jobs in the successful job queue"
+                    % self.__successful_job_queue.unfinished_tasks
+                )
+                self.__logger.debug(
+                    "%d unfinished jobs in the failed job queue"
+                    % self.__failed_job_queue.unfinished_tasks
+                )
             time.sleep(self.__log_output_sleep_duration)
 
     def __process_queued_jobs(self):
@@ -732,6 +734,7 @@ class Commander(object):
                 self.__is_running = False
 
         # spin up a thread to output queue load information
+        self.__queue_monitor_output_lock.acquire()
         job_queue_monitor_thread = threading.Thread(
             name="QueueMonitor", target=self.__monitor_job_queues
         )
@@ -835,6 +838,7 @@ class Commander(object):
                 self.__logger.debug(
                     "Checking remotes for completed jobs to download and process"
                 )
+                self.__queue_monitor_output_lock.release()
                 for (workgroup_name, hosts, sources, jobs_per_host) in work_groups:
                     if hosts == None:
                         continue
@@ -844,6 +848,7 @@ class Commander(object):
                 self.__logger.debug("Waiting for completed jobs to be processed.")
                 self.__successful_job_queue.join()
                 self.__failed_job_queue.join()
+                self.__queue_monitor_output_lock.acquire()
 
                 # check for scheduled hosts
                 self.__logger.debug(
@@ -890,6 +895,7 @@ class Commander(object):
         # signal job processing threads to exit once they have finished all
         # queued work
         self.__is_processing_jobs = False
+        self.__queue_monitor_output_lock.release()
 
         # wait for the job processing threads to exit
         for job_processing_thread in job_processing_threads:

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -701,7 +701,9 @@ class Commander(object):
                 self.__logger.error("Unable to start job processing thread #%s", t)
                 self.__logger.error(e)
                 # bail out
-                self.__logger.critical("Shutting down due to inability to start threads.")
+                self.__logger.critical(
+                    "Shutting down due to inability to start threads."
+                )
                 self.__is_running = False
 
         # pairs of hosts and job sources

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -700,6 +700,9 @@ class Commander(object):
             except Exception as e:
                 self.__logger.error("Unable to start job processing thread #%s", t)
                 self.__logger.error(e)
+                # bail out
+                self.__logger.critical("Shutting down due to inability to start threads.")
+                self.__is_running = False
 
         # pairs of hosts and job sources
         work_groups = (

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -452,17 +452,8 @@ class Commander(object):
             time.sleep(self.__log_output_sleep_duration)
 
     def __process_queued_jobs(self):
-        # run as long as the commander is processing jobs or the queues are not empty
-        #
-        # There is a race condition inherent to using Queue.empty() in a loop because
-        # items can be added after Queue.empty() has already returned True. We can
-        # safely ignore this because no work will be added to the queues after
-        # self.__is_processing_jobs is set to False.
-        while (
-            self.__is_processing_jobs
-            or not self.__successful_job_queue.empty()
-            or not self.__failed_job_queue.empty()
-        ):
+        # run as long as the commander is processing jobs
+        while self.__is_processing_jobs:
             job_path = None
 
             # check the successful jobs queue

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -452,28 +452,42 @@ class Commander(object):
                     time.sleep(10)
 
     def __process_successful_job(self, job_path):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         for sink in self.__success_sinks:
             if sink.can_handle(job_path):
-                self.__logger.info("Processing %s with %s" % (job_path, sink))
+                self.__logger.info(
+                    "[%s] Processing %s with %s" % (thread_name, job_path, sink)
+                )
                 sink.handle(job_path)
-                self.__logger.info("Processing completed")
+                self.__logger.info("[%s] Processing completed" % thread_name)
                 if not self.__test_mode and not self.__keep_successes:
                     shutil.rmtree(job_path)
-                    self.__logger.info("%s deleted" % job_path)
+                    self.__logger.info("[%s] %s deleted" % (thread_name, job_path))
                 return
-        self.__logger.warning("No handler was able to process %s" % job_path)
+        self.__logger.warning(
+            "[%s] No handler was able to process %s" % (thread_name, job_path)
+        )
 
     def __process_failed_job(self, job_path):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         for sink in self.__failure_sinks:
             if sink.can_handle(job_path):
-                self.__logger.warning("Processing %s with %s" % (job_path, sink))
+                self.__logger.warning(
+                    "[%s] Processing %s with %s" % (thread_name, job_path, sink)
+                )
                 sink.handle(job_path)
-                self.__logger.info("Processing completed")
+                self.__logger.info("[%s] Processing completed" % thread_name)
                 if not self.__test_mode and not self.__keep_failures:
                     shutil.rmtree(job_path)
-                    self.__logger.info("%s deleted" % job_path)
+                    self.__logger.info("[%s] %s deleted" % (thread_name, job_path))
                 return
-        self.__logger.warning("No handler was able to process %s" % job_path)
+        self.__logger.warning(
+            "[%s] No handler was able to process %s" % (thread_name, job_path)
+        )
 
     def handle_term(self, signal, frame):
         self.__logger.warning(

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -438,7 +438,8 @@ class Commander(object):
             counts[lowest_host] += 1
 
     def __monitor_job_queues(self):
-        # output the approximate amount of work on each of the queues every 10 seconds
+        # Output the number of jobs that are not done for each queue every
+        # self.__log_output_sleep_duration seconds while work is on the queues.
         while self.__is_processing_jobs:
             with self.__queue_monitor_output_lock:
                 self.__logger.debug(

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -674,8 +674,10 @@ class Commander(object):
                 )
                 job_processing_threads.append(job_processing_thread)
                 job_processing_thread.start()
-            except Exception:
+            except Exception as e:
                 self.__logger.error("Unable to start job processing thread #%s", t)
+                self.__logger.error(e)
+
         # pairs of hosts and job sources
         work_groups = (
             (NMAP_WORKGROUP, nmap_hosts, self.__nmap_sources, jobs_per_nmap_host),

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -645,6 +645,12 @@ class Commander(object):
         self.__test_mode = config.getboolean(config_section, TEST_MODE)
         self.__logger.info("Test mode: %s", self.__test_mode)
         self.__keep_failures = config.getboolean(config_section, KEEP_FAILURES)
+        job_processing_thread_count = config.getint(
+            config_section, JOB_PROCESSING_THREADS
+        )
+        self.__logger.info(
+            "Number of job processing threads: %d", job_processing_thread_count
+        )
         self.__logger.info("Keep failed jobs: %s", self.__keep_failures)
         self.__keep_successes = config.getboolean(config_section, KEEP_SUCCESSES)
         self.__logger.info("Keep successful jobs: %s", self.__keep_successes)
@@ -664,9 +670,6 @@ class Commander(object):
 
         # spin up the thread pool to process retrieved work
         job_processing_threads = []
-        job_processing_thread_count = config.getint(
-            config_section, JOB_PROCESSING_THREADS
-        )
         for t in range(job_processing_thread_count):
             try:
                 job_processing_thread = threading.Thread(

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -452,46 +452,54 @@ class Commander(object):
             time.sleep(self.__log_output_sleep_duration)
 
     def __process_queued_jobs(self):
-        # run as long as the commander is processing jobs
-        while self.__is_processing_jobs:
+
+        # define an inner function to process jobs
+        def process_job_from_queue(target_job_queue, job_processing_function):
+            """Helper function to process jobs from a queue.
+
+            Args:
+                target_job_queue (Queue.Queue): The queue to get a job to process.
+                job_processing_function (callable): The function used to process a job.
+
+            Returns:
+                The job path that was processed or None if the queue was empty.
+            """
             job_path = None
 
             # check the successful jobs queue
             try:
-                job_path = self.__successful_job_queue.get(timeout=1)
+                job_path = target_job_queue.get(timeout=1)
             except Queue.Empty:
-                pass
+                return job_path
 
+            try:
+                job_processing_function(job_path)
+            except Exception, e:
+                self.__logger.critical(e)
+                self.__logger.critical(traceback.format_exc())
+
+            # report task completion no matter what so the queue can be joined
+            target_queue.task_done()
+
+            # return job processing duration
+            return job_path
+
+        # run as long as the commander is processing jobs
+        while self.__is_processing_jobs:
             # process successful job
-            if job_path is not None:
-                try:
-                    self.__process_successful_job(job_path)
-                except Exception, e:
-                    self.__logger.critical(e)
-                    self.__logger.critical(traceback.format_exc())
+            job_processing_results = process_job_from_queue(
+                self.__successful_job_queue, self.__process_successful_job
+            )
 
-                # report task completion no matter what so the queue can be joined
-                self.__successful_job_queue.task_done()
-            else:
-                # check the failed jobs queue
-                try:
-                    job_path = self.__failed_job_queue.get(timeout=1)
-                except Queue.Empty:
-                    pass
+            # process failed job if a successful job was not processed
+            if job_processing_results is None:
+                job_processing_results = process_job_from_queue(
+                    self.__failed_job_queue, self.__process_failed_job
+                )
 
-                # process failed job
-                if job_path is not None:
-                    try:
-                        self.__process_failed_job(job_path)
-                    except Exception, e:
-                        self.__logger.critical(e)
-                        self.__logger.critical(traceback.format_exc())
-
-                    # report task completion no matter what so the queue can be joined
-                    self.__failed_job_queue.task_done()
-                else:
-                    # sleep if both queues are empty
-                    time.sleep(self.__job_processing_sleep_duration)
+            # sleep if both queues are empty
+            if job_processing_results is None:
+                time.sleep(self.__job_processing_sleep_duration)
 
     def __process_successful_job(self, job_path):
         # Get the name of the current thread

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -472,10 +472,12 @@ class Commander(object):
             if job_path is not None:
                 try:
                     self.__process_successful_job(job_path)
-                    self.__successful_job_queue.task_done()
                 except Exception, e:
                     self.__logger.critical(e)
                     self.__logger.critical(traceback.format_exc())
+
+                # report task completion no matter what so the queue can be joined
+                self.__successful_job_queue.task_done()
             else:
                 # check the failed jobs queue
                 try:
@@ -487,10 +489,12 @@ class Commander(object):
                 if job_path is not None:
                     try:
                         self.__process_failed_job(job_path)
-                        self.__failed_job_queue.task_done()
                     except Exception, e:
                         self.__logger.critical(e)
                         self.__logger.critical(traceback.format_exc())
+
+                    # report task completion no matter what so the queue can be joined
+                    self.__failed_job_queue.task_done()
                 else:
                     # sleep if both queues are empty
                     time.sleep(self.__job_processing_sleep_duration)

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -440,11 +440,12 @@ class Commander(object):
         # output the approximate amount of work on each of the queues every 10 seconds
         while self.__is_processing_jobs:
             self.__logger.debug(
-                "%d jobs in the successful job queue"
-                % self.__successful_job_queue.qsize()
+                "%d unfinished jobs in the successful job queue"
+                % self.__successful_job_queue.unfinished_tasks
             )
             self.__logger.debug(
-                "%d jobs in the failed job queue" % self.__failed_job_queue.qsize()
+                "%d unfinished jobs in the failed job queue"
+                % self.__failed_job_queue.unfinished_tasks
             )
             time.sleep(self.__log_output_sleep_duration)
 

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -909,7 +909,7 @@ class Commander(object):
 
 
 def main():
-    args = docopt(__doc__, version="v1.0.2")
+    args = docopt(__doc__, version="v1.1.0")
     workingDir = os.path.join(os.getcwd(), args["<working-dir>"])
     if not os.path.exists(workingDir):
         print >>sys.stderr, 'Working directory "%s" does not exist.  Attempting to create...' % workingDir

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -730,7 +730,9 @@ class Commander(object):
             self.__logger.error("Unable to start job queue monitoring thread")
             self.__logger.error(e)
             # bail out
-            self.__logger.critical("Shutting down due to inability to start queue monitoring thread.")
+            self.__logger.critical(
+                "Shutting down due to inability to start queue monitoring thread."
+            )
             self.__is_running = False
 
         # pairs of hosts and job sources

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -709,7 +709,9 @@ class Commander(object):
         # spin up the thread pool to process retrieved work
         job_processing_threads = []
         for t in range(job_processing_thread_count):
-            job_processing_thread = threading.Thread(target=self.__process_queued_jobs)
+            job_processing_thread = threading.Thread(
+                name="JobProcessor-%d" % t, target=self.__process_queued_jobs
+            )
             job_processing_threads.append(job_processing_thread)
             try:
                 job_processing_thread.start()
@@ -723,7 +725,9 @@ class Commander(object):
                 self.__is_running = False
 
         # spin up a thread to output queue load information
-        job_queue_monitor_thread = threading.Thread(target=self.__monitor_job_queues)
+        job_queue_monitor_thread = threading.Thread(
+            name="QueueMonitor", target=self.__monitor_job_queues
+        )
         try:
             job_queue_monitor_thread.start()
         except Exception as e:

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -147,8 +147,10 @@ class Commander(object):
         self.__hosts_on_cooldown = []
         self.__is_processing_jobs = True
         self.__is_running = True
+        self.__job_processing_sleep_duration = 1
         self.__keep_failures = False
         self.__keep_successes = False
+        self.__log_output_sleep_duration = 10
         self.__nessus_sources = []
         self.__next_scan_limit = 2000
         self.__nmap_sources = []
@@ -444,7 +446,7 @@ class Commander(object):
             self.__logger.debug(
                 "%d jobs in the failed job queue" % self.__failed_job_queue.qsize()
             )
-            time.sleep(10)
+            time.sleep(self.__log_output_sleep_duration)
 
     def __process_queued_jobs(self):
         # run as long as the commander is processing jobs or the queues are not empty
@@ -491,7 +493,7 @@ class Commander(object):
                         self.__logger.critical(traceback.format_exc())
                 else:
                     # sleep if both queues are empty
-                    time.sleep(1)
+                    time.sleep(self.__job_processing_sleep_duration)
 
     def __process_successful_job(self, job_path):
         # Get the name of the current thread
@@ -549,7 +551,7 @@ class Commander(object):
     def __check_database_pause(self):
         while self.__ch_db.should_commander_pause() and self.__is_running:
             self.__logger.info("Commander is paused due to database request.")
-            time.sleep(10)
+            time.sleep(self.__log_output_sleep_duration)
             self.__check_stop_file()
 
     def __write_config(self):

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -434,8 +434,12 @@ class Commander(object):
             counts[lowest_host] += 1
 
     def __process_queued_jobs(self):
-        # run as long as the commander is running
-        while self.__is_running:
+        # run as long as the commander is running or the queues are not empty
+        while (
+            self.__is_running
+            or not self.__successful_job_queue.empty()
+            or not self.__failed_job_queue.empty()
+        ):
             try:
                 # check the successful jobs queue
                 job_path = self.__successful_job_queue.get(timeout=1)

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -709,11 +709,9 @@ class Commander(object):
         # spin up the thread pool to process retrieved work
         job_processing_threads = []
         for t in range(job_processing_thread_count):
+            job_processing_thread = threading.Thread(target=self.__process_queued_jobs)
+            job_processing_threads.append(job_processing_thread)
             try:
-                job_processing_thread = threading.Thread(
-                    target=self.__process_queued_jobs
-                )
-                job_processing_threads.append(job_processing_thread)
                 job_processing_thread.start()
             except Exception as e:
                 self.__logger.error("Unable to start job processing thread #%s", t)
@@ -725,10 +723,8 @@ class Commander(object):
                 self.__is_running = False
 
         # spin up a thread to output queue load information
+        job_queue_monitor_thread = threading.Thread(target=self.__monitor_job_queues)
         try:
-            job_queue_monitor_thread = threading.Thread(
-                target=self.__monitor_job_queues
-            )
             job_queue_monitor_thread.start()
         except Exception as e:
             self.__logger.error("Unable to start job queue monitoring thread")

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -146,6 +146,7 @@ class Commander(object):
         self.__failed_job_queue = None
         self.__host_exceptions = defaultdict(lambda: 0)
         self.__hosts_on_cooldown = []
+        self.__is_processing_jobs = True
         self.__is_running = True
         self.__keep_failures = False
         self.__keep_successes = False
@@ -434,9 +435,14 @@ class Commander(object):
             counts[lowest_host] += 1
 
     def __process_queued_jobs(self):
-        # run as long as the commander is running or the queues are not empty
+        # run as long as the commander is processing jobs or the queues are not empty
+        #
+        # There is a race condition inherent to using Queue.empty() in a loop because
+        # items can be added after Queue.empty() has already returned True. We can
+        # safely ignore this because no work will be added to the queues after
+        # self.__is_processing_jobs is set to False.
         while (
-            self.__is_running
+            self.__is_processing_jobs
             or not self.__successful_job_queue.empty()
             or not self.__failed_job_queue.empty()
         ):
@@ -845,6 +851,10 @@ class Commander(object):
             except Exception, e:
                 self.__logger.critical(e)
                 self.__logger.critical(traceback.format_exc())
+
+        # signal job processing threads to exit once they have finished all
+        # queued work
+        self.__is_processing_jobs = False
 
         # wait for the job processing threads to exit
         for job_processing_thread in job_processing_threads:

--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -807,6 +807,7 @@ class Commander(object):
                     execute(self.__done_jobs, self, hosts=hosts)
 
                 # wait for work to process
+                self.__logger.debug("Waiting for completed jobs to be processed.")
                 self.__successful_job_queue.join()
                 self.__failed_job_queue.join()
 

--- a/cyhy_commander/nessus/nessus_importer.py
+++ b/cyhy_commander/nessus/nessus_importer.py
@@ -6,6 +6,7 @@ from bson.errors import InvalidDocument
 import netaddr
 import gzip
 import logging
+import threading
 from cyhy.core import UNKNOWN_OWNER
 from cyhy.db import CHDatabase, VulnTicketManager
 from cyhy.util import util
@@ -50,7 +51,10 @@ class NessusImporter(object):
         self.manual_scan = manual_scan
 
     def process(self, filename, gzipped=False):
-        self.__logger.debug("Starting processing of %s" % filename)
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
+        self.__logger.debug("[%s] Starting processing of %s" % (thread_name, filename))
         if self.manual_scan:
             # if we are doing a manual scan import we have to assume a current time
             self.current_ip_time = util.utcnow()
@@ -62,20 +66,28 @@ class NessusImporter(object):
         f.close()
 
     def __try_to_clear_latest_flags(self):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         # Once the ticket manager has all its information,
         # it can clear the previous latest flags
         if self.ticket_manager.ready_to_clear_vuln_latest_flags():
             self.__logger.debug(
-                'Ticket manager IS READY to clear VulnScan "latest" flags'
+                '[%s] Ticket manager IS READY to clear VulnScan "latest" flags'
+                % thread_name
             )
             self.ticket_manager.clear_vuln_latest_flags()
             self.attempted_to_clear_latest_flags = True
         else:
             self.__logger.debug(
-                'Ticket manager IS NOT READY to clear VulnScan "latest" flags'
+                '[%s] Ticket manager IS NOT READY to clear VulnScan "latest" flags'
+                % thread_name
             )
 
     def targets_callback(self, targets_string):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         """list of targets read from the policy section
         clear latest flags, and change host state
         this is done here since not all targets necessarily
@@ -99,35 +111,53 @@ class NessusImporter(object):
                 if len(parts) == 2 and parts[1].endswith("]"):
                     t = parts[1][:-1]
                 else:
-                    self.__logger.warning("Skipping malformed target: '%s'" % t.strip())
+                    self.__logger.warning(
+                        "[%s] Skipping malformed target: '%s'"
+                        % (thread_name, t.strip())
+                    )
                     continue
             self.targets.add(netaddr.IPAddress(t))
-        self.__logger.debug("Found %d targets in Nessus file" % len(self.targets))
+        self.__logger.debug(
+            "[%s] Found %d targets in Nessus file" % (thread_name, len(self.targets))
+        )
         self.ticket_manager.ips = self.targets
         self.__try_to_clear_latest_flags()
 
     def plugin_set_callback(self, plugin_set_string):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         string_list = plugin_set_string.split(";")
         if (
             string_list[-1] == ""
         ):  # this list ends with a ; creating a non-int empty string
             string_list.pop()
         plugin_set = set(int(s) for s in string_list)
-        self.__logger.debug("Found %d plugin_ids in Nessus file" % len(plugin_set))
+        self.__logger.debug(
+            "[%s] Found %d plugin_ids in Nessus file" % (thread_name, len(plugin_set))
+        )
         self.ticket_manager.source_ids = plugin_set
         self.__try_to_clear_latest_flags()
 
     def port_range_callback(self, port_range_string):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         # The base policy port range was used
         if port_range_string == "default":
             # Match the base policy value found in /extras/policy.xml
             port_range_string = "1-65535"
         ports = set(util.range_string_to_list(port_range_string))
-        self.__logger.debug("Found %d ports in Nessus file" % len(ports))
+        self.__logger.debug(
+            "[%s] Found %d ports in Nessus file" % (thread_name, len(ports))
+        )
         self.ticket_manager.ports = ports
         self.__try_to_clear_latest_flags()
 
     def host_callback(self, parsedHost):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         # some fragile hosts don't list their host_ip
         # fallback to name
         if parsedHost.has_key("host_ip"):
@@ -140,8 +170,8 @@ class NessusImporter(object):
                 # When parsedHost['name'] is not a valid IP (see CYHY-113 in Jira)
                 self.current_ip = None
                 self.__logger.warning(
-                    "Skipping vulnerability reports; invalid host IP detected: %s"
-                    % parsedHost["name"]
+                    "[%s] Skipping vulnerability reports; invalid host IP detected: %s"
+                    % (thread_name, parsedHost["name"])
                 )
                 return
         parsedHost["ip"] = self.current_ip
@@ -188,8 +218,9 @@ class NessusImporter(object):
             self.current_host_owner = UNKNOWN_OWNER
             if self.current_hostname:
                 self.__logger.warning(
-                    "Could not find owner for %s - %s (%d)"
+                    "[%s] Could not find owner for %s - %s (%d)"
                     % (
+                        thread_name,
                         self.current_hostname,
                         self.current_ip,
                         int(self.current_ip),
@@ -197,20 +228,23 @@ class NessusImporter(object):
                 )
             else:
                 self.__logger.warning(
-                    "Could not find owner for %s (%d)"
-                    % (self.current_ip, int(self.current_ip))
+                    "[%s] Could not find owner for %s (%d)"
+                    % (thread_name, self.current_ip, int(self.current_ip))
                 )
 
         # Nessus host docs are not stored as we already have better data from nmap
 
     def report_callback(self, parsedReport):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         # not storing severity 0 reports or reports with invalid IPs
         if parsedReport["severity"] == 0:
             return
         if self.current_ip is None:
             self.__logger.warning(
-                "No current IP; skipping vulnerability report: %s"
-                % parsedReport["plugin_name"]
+                "[%s] No current IP; skipping vulnerability report: %s"
+                % (thread_name, parsedReport["plugin_name"])
             )
             return
         report = self.__db.VulnScanDoc()
@@ -231,6 +265,9 @@ class NessusImporter(object):
         self.ticket_manager.open_ticket(report, "vulnerability detected")
 
     def end_callback(self):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         for ip in self.targets:
             if self.manual_scan:
                 # update host priority and reschedule host
@@ -241,11 +278,13 @@ class NessusImporter(object):
         self.ticket_manager.close_tickets()
         if not self.attempted_to_clear_latest_flags:
             self.__logger.warning(
-                'Reached end of Nessus import but did not clear "latest" flags'
+                '[%s] Reached end of Nessus import but did not clear "latest" flags'
+                % thread_name
             )
             self.__logger.warning(
-                "Ticket manager state counts: %d ips, %d ports, %d source_ids"
+                "[%s] Ticket manager state counts: %d ips, %d ports, %d source_ids"
                 % (
+                    thread_name,
                     len(self.ticket_manager.ips),
                     len(self.ticket_manager.ports),
                     len(self.ticket_manager.source_ids),
@@ -253,5 +292,6 @@ class NessusImporter(object):
             )
         else:
             self.__logger.debug(
-                "Reached end of Nessus import, VulnScan latest flags were cleared."
+                "[%s] Reached end of Nessus import, VulnScan latest flags were cleared."
+                % thread_name
             )

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -2,6 +2,7 @@
 
 # built-in python libraries
 import logging
+import threading
 from xml.sax import parse
 
 # third-party libraries (install with pip)
@@ -93,13 +94,18 @@ class NmapImporter(object):
         f.close()
 
     def __store_port_details(self, parsed_host):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         has_at_least_one_open_port = False
         ip = parsed_host["addr"]
         host_doc = self.__db.HostDoc.get_by_ip(ip)
         if host_doc:
             ip_owner = host_doc.get("owner", UNKNOWN_OWNER)
         else:
-            self.__logger.warning("No HostDoc found for IP %s" % str(ip))
+            self.__logger.warning(
+                "[%s] No HostDoc found for IP %s" % (thread_name, str(ip))
+            )
             ip_owner = UNKNOWN_OWNER
         for (port, details) in parsed_host["ports"].items():
             if details["state"] != "open":  # only storing open ports

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-commander",
-    version="1.0.2",
+    version="1.1.0",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the commander to process completed jobs that are retrieved from scanner instances using a thread pool and queues.

> [!NOTE]
> This PR adds a new `job-processing-threads` required key to the configuration file. I plan on updating our deployment configuration to include this key once this PR is ready for review.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Processing completed work in a single-threaded manner has been showing a significant performance hit for commander cycles. This will hopefully allow us to parallelize processing completed jobs that are retrieved to reduce the duration of commander cycles.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

- Verified the thread pool started with the expected number of threads.
- Verified that when the commander service is stopped and there is no work in the queue, the threads cleanly exit and allow the commander to gracefully shutdown.
- Verified that a thread can process work from the retrieved job queue.
- Verified that the commander's `do_work` loop will wait for the queues to empty before continuing.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
