### PR TITLE
Bugfix: Correctly handle hostnames in `TryAgainSink` and improve error handling for hostname/IP targets

### DIFF
--- a/cyhy_commander/job_sink.py
+++ b/cyhy_commander/job_sink.py
@@ -95,5 +95,16 @@ class TryAgainSink(object):
         target_file = glob.glob(target_glob)[0]
         with open(target_file) as f:
             for ip_line in f:
+                # It's possible that the target file contains hostnames, so
+                # check if any targets are a hostname and an IP address (e.g.
+                # "foo.gov[192.168.1.1]"), and if so, extract the IP address.
+                #
+                # This could be done via regex, but I don't think there's any
+                # benefit that justifies the additional import.  If the target
+                # is malformed (e.g. something other than a valid IP in the
+                # brackets, no closing bracket, etc.), casting to an IPAddress
+                # will fail regardless of how we parse it.
+                if "[" in ip_line:
+                    ip_line = ip_line.strip().split("[")[1][:-1]
                 ip = netaddr.IPAddress(ip_line)
                 self.__ch_db.transition_host(ip, was_failure=True)

--- a/cyhy_commander/job_sink.py
+++ b/cyhy_commander/job_sink.py
@@ -97,6 +97,10 @@ class TryAgainSink(object):
         target_file = glob.glob(target_glob)[0]
         with open(target_file) as f:
             for ip_line in f:
+                # TODO: Create a helper function for this logic since it's
+                # duplicated in multiple places now.  See issue #18 for more
+                # details.
+                #
                 # It's possible that the target file contains hostnames, so
                 # check if any targets are a hostname and an IP address (e.g.
                 # "foo.gov[192.168.1.1]"), and if so, extract the IP address.

--- a/cyhy_commander/job_sink.py
+++ b/cyhy_commander/job_sink.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import logging
 import random
 from cyhy.core import *
 from cyhy.db import CHDatabase
@@ -83,6 +84,7 @@ class TryAgainSink(object):
     def __init__(self, db):
         self.__db = db
         self.__ch_db = CHDatabase(db)
+        self.__logger = logging.getLogger(__name__)
 
     def __str__(self):
         return "<TryAgainSink %s>" % (self.__ch_db)
@@ -100,11 +102,20 @@ class TryAgainSink(object):
                 # "foo.gov[192.168.1.1]"), and if so, extract the IP address.
                 #
                 # This could be done via regex, but I don't think there's any
-                # benefit that justifies the additional import.  If the target
-                # is malformed (e.g. something other than a valid IP in the
-                # brackets, no closing bracket, etc.), casting to an IPAddress
-                # will fail regardless of how we parse it.
+                # benefit that justifies the additional import.  Note that if
+                # something other than a valid is IP in the brackets, casting to
+                # an IPAddress will fail regardless of how we parse it.
                 if "[" in ip_line:
-                    ip_line = ip_line.strip().split("[")[1][:-1]
+                    parts = ip_line.strip().split("[")
+                    if len(parts) == 2 and parts[1].endswith("]"):
+                        ip_line = parts[1][:-1]
+                    else:
+                        self.__logger.warning(
+                            "Skipping malformed target '%s' in job %s" % (
+                                ip_line.strip(),
+                                job_path
+                            )
+                        )
+                        continue
                 ip = netaddr.IPAddress(ip_line)
                 self.__ch_db.transition_host(ip, was_failure=True)

--- a/cyhy_commander/nessus/nessus_importer.py
+++ b/cyhy_commander/nessus/nessus_importer.py
@@ -83,7 +83,7 @@ class NessusImporter(object):
         targets = targets_string.split(",")
         self.targets = netaddr.IPSet()
         for t in targets:
-            # If any targets are a hostname and an IP addresss (e.g.
+            # If any targets are a hostname and an IP address (e.g.
             # "foo.gov[192.168.1.1]"), extract the IP address.
             #
             # This could be done via regex, but I don't think there's any

--- a/cyhy_commander/nessus/nessus_importer.py
+++ b/cyhy_commander/nessus/nessus_importer.py
@@ -83,6 +83,10 @@ class NessusImporter(object):
         targets = targets_string.split(",")
         self.targets = netaddr.IPSet()
         for t in targets:
+            # TODO: Create a helper function for this logic since it's
+            # duplicated in multiple places now.  See issue #18 for more
+            # details.
+            #
             # If any targets are a hostname and an IP address (e.g.
             # "foo.gov[192.168.1.1]"), extract the IP address.
             #

--- a/cyhy_commander/nessus/nessus_importer.py
+++ b/cyhy_commander/nessus/nessus_importer.py
@@ -87,12 +87,18 @@ class NessusImporter(object):
             # "foo.gov[192.168.1.1]"), extract the IP address.
             #
             # This could be done via regex, but I don't think there's any
-            # benefit that justifies the additional import.  If the target is
-            # malformed (e.g. something other than a valid IP in the brackets,
-            # no closing bracket, etc.), casting to an IPAddress will fail
-            # regardless of how we parse it.
+            # benefit that justifies the additional import.  Note that if
+            # something other than a valid is IP in the brackets, casting to an
+            # IPAddress will fail regardless of how we parse it.
             if "[" in t:
-                t = t.strip().split("[")[1][:-1]
+                parts = t.strip().split("[")
+                if len(parts) == 2 and parts[1].endswith("]"):
+                    t = parts[1][:-1]
+                else:
+                    self.__logger.warning(
+                        "Skipping malformed target: '%s'" % t.strip()
+                    )
+                    continue
             self.targets.add(netaddr.IPAddress(t))
         self.__logger.debug("Found %d targets in Nessus file" % len(self.targets))
         self.ticket_manager.ips = self.targets

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-commander",
-    version="1.0.0",
+    version="1.0.1",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a bug so that jobs in the `TryAgainSink` are processed correctly.

Some Copilot comments (https://github.com/cisagov/cyhy-commander/pull/17#discussion_r2445944366 and https://github.com/cisagov/cyhy-commander/pull/17#discussion_r2445944374) convinced me to make an additional tweak to better handle invalid hostname/IP combos (see https://github.com/cisagov/cyhy-commander/pull/17/commits/5f001a586b09bc2cd1d9b50d68513b52a01be6b6).

A typo in a comment was also fixed since I noticed it (https://github.com/cisagov/cyhy-commander/pull/17/commits/afb36277d31f53d311828061d5e55e5ea2aa9fc3).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Before this PR, if a vuln scan job containing a hostname ended up in the `TryAgainSink`, it would fail to be processed because the hostname/IP combo (e.g. `foo.gov[192.168.1.1]`) could not be cleanly converted to an IP address.  This PR handles that situation correctly, in the [same way that we do it in `nessus/nessus_importer.py`](https://github.com/cisagov/cyhy-commander/blob/2ae9cb7b73f8c18f40ea50f80ef7613034bb0965/cyhy_commander/nessus/nessus_importer.py#L85-L96).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I paused the commander in my dev environment while some vulnscan jobs were being executed (scanned).  I waited until I had two completed vulnscan jobs, one containing hostnames in the targets file and one without.  Even though both jobs completed successfully, I manually changed the return code from "0" to "1" in the `.done` file for each job, thus simulating a job failure.  Then, I unpaused the commander and verified that both "failed" jobs were successfully handled by the commander, meaning that their contents were read (both "naked" IPs and hostname/IP combos) and then new jobs were created to re-scan the "failed" jobs.

To test the new logic for logging malformed targets (in https://github.com/cisagov/cyhy-commander/pull/17/commits/5f001a586b09bc2cd1d9b50d68513b52a01be6b6), I did a similar test as above, except that I manually edited the targets file to include some malformed targets, then verified that they were skipped and logged as expected:
```
2025-10-21 16:48:51,438 WARNING cyhy_commander.commander - [Thread-2] Processing failed/VULNSCAN-20251021T141113.342234+0000 with <TryAgainSink <CHDatabase Database(MongoClient('database1.cyhy', 27017), u'cyhy')>>
2025-10-21 16:48:51,454 WARNING cyhy_commander.job_sink - Skipping malformed target 'bad.test.gov[1.2.3.4' in job failed/VULNSCAN-20251021T141113.342234+0000
2025-10-21 16:48:51,455 WARNING cyhy_commander.job_sink - Skipping malformed target 'messed-up.gov[1.2 ][bonus.hostname]stuff' in job failed/VULNSCAN-20251021T141113.342234+0000
2025-10-21 16:48:51,457 WARNING cyhy_commander.job_sink - Skipping malformed target 'another.bad.test[[' in job failed/VULNSCAN-20251021T141113.342234+0000
2025-10-21 16:48:51,461 WARNING cyhy_commander.job_sink - Skipping malformed target 'last-bad-test.gov[this-is-bad    really bad' in job failed/VULNSCAN-20251021T141113.342234+0000
2025-10-21 16:48:51,465 INFO cyhy_commander.commander - [Thread-2] Processing completed
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this change to Production.
