### PR TITLE
Add a workflow to automatically `black`en on pull requests

### DIFF
--- a/.github/workflows/blacken.yml
+++ b/.github/workflows/blacken.yml
@@ -1,0 +1,96 @@
+---
+name: Blacken repository
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  blacken:
+    needs:
+      - diagnostics
+    permissions:
+      # stefanzweifel/git-auto-commit-action needs this to commit changes
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: actions/checkout@v5
+        with:
+          # Needed by stefanzweifel/git-auto-commit-action to support the pull_request
+          # trigger.
+          ref: ${{ github.head_ref }}
+      - name: Blacken project
+        uses: cisagov/action-blacken-python2@482be061341ecfdfdee0ba78e27556d77aadd26d
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Format project with `black`

--- a/.github/workflows/blacken.yml
+++ b/.github/workflows/blacken.yml
@@ -89,7 +89,7 @@ jobs:
           # trigger.
           ref: ${{ github.head_ref }}
       - name: Blacken project
-        uses: cisagov/action-blacken-python2@482be061341ecfdfdee0ba78e27556d77aadd26d
+        uses: cisagov/action-blacken-python2@v1
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/cyhy_commander/job_sink.py
+++ b/cyhy_commander/job_sink.py
@@ -115,10 +115,8 @@ class TryAgainSink(object):
                         ip_line = parts[1][:-1]
                     else:
                         self.__logger.warning(
-                            "Skipping malformed target '%s' in job %s" % (
-                                ip_line.strip(),
-                                job_path
-                            )
+                            "Skipping malformed target '%s' in job %s"
+                            % (ip_line.strip(), job_path)
                         )
                         continue
                 ip = netaddr.IPAddress(ip_line)

--- a/cyhy_commander/nessus/nessus_importer.py
+++ b/cyhy_commander/nessus/nessus_importer.py
@@ -99,9 +99,7 @@ class NessusImporter(object):
                 if len(parts) == 2 and parts[1].endswith("]"):
                     t = parts[1][:-1]
                 else:
-                    self.__logger.warning(
-                        "Skipping malformed target: '%s'" % t.strip()
-                    )
+                    self.__logger.warning("Skipping malformed target: '%s'" % t.strip())
                     continue
             self.targets.add(netaddr.IPAddress(t))
         self.__logger.debug("Found %d targets in Nessus file" % len(self.targets))


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a GitHub Actions workflow to automatically run `black` against the project and commit any changes.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will help ensure that this Python 2 project remains formatted even without our `pre-commit` configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
