### PR TITLE
Add our label configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,73 @@
+---
+# Each entry in this file is a label that will be applied to pull requests
+# if there is a match based on the matching rules for the entry. Please see
+# the actions/labeler documentation for more information:
+# https://github.com/actions/labeler#match-object
+#
+# Note: Verify that the label you want to use is defined in the
+# crazy-max/ghaction-github-labeler configuration file located at
+# .github/labels.yml.
+
+ansible:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/ansible/**"
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          # Add any dependency files used.
+          - .pre-commit-config.yaml
+          - requirements*.txt
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/compose*.yml"
+          - "**/docker-compose*.yml"
+          - "**/Dockerfile*"
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+github-actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.js"
+packer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.pkr.hcl"
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+terraform:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.tf"
+test:
+  - changed-files:
+      - any-glob-to-any-file:
+          # Add any test-related files or paths.
+          - .ansible-lint
+          - .bandit.yml
+          - .flake8
+          - .isort.cfg
+          - .mdl_config.yaml
+          - .yamllint
+typescript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.ts"
+upstream update:
+  - head-branch:
+      # Any Lineage pull requests should use this branch.
+      - lineage/skeleton
+version bump:
+  - changed-files:
+      - any-glob-to-any-file:
+          # Ensure this matches your version tracking file(s).
+          - version.txt

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,10 @@ ansible:
   - changed-files:
       - any-glob-to-any-file:
           - "**/ansible/**"
+cyhy-runner jobs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - cyhy_commander/jobs/**
 dependencies:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,7 @@ dependencies:
           # Add any dependency files used.
           - .pre-commit-config.yaml
           - requirements*.txt
+          - setup.py
 docker:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,91 @@
+---
+# Rather than breaking up descriptions into multiline strings we disable that
+# specific rule in yamllint for this file.
+# yamllint disable rule:line-length
+- color: f15a53
+  description: Pull requests that update Ansible code
+  name: ansible
+- color: eb6420
+  description: This issue or pull request is awaiting the outcome of another issue or pull request
+  name: blocked
+- color: "000000"
+  description: This issue or pull request involves changes to existing functionality
+  name: breaking change
+- color: d73a4a
+  description: This issue or pull request addresses broken functionality
+  name: bug
+- color: 07648d
+  description: This issue will be advertised on code.gov's Open Tasks page (https://code.gov/open-tasks)
+  name: code.gov
+- color: 0366d6
+  description: Pull requests that update a dependency file
+  name: dependencies
+- color: 2497ed
+  description: Pull requests that update Docker code
+  name: docker
+- color: 5319e7
+  description: This issue or pull request improves or adds to documentation
+  name: documentation
+- color: cfd3d7
+  description: This issue or pull request already exists or is covered in another issue or pull request
+  name: duplicate
+- color: b005bc
+  description: A high-level objective issue encompassing multiple issues instead of a specific unit of work
+  name: epic
+- color: "000000"
+  description: Pull requests that update GitHub Actions code
+  name: github-actions
+- color: 0e8a16
+  description: This issue or pull request is well-defined and good for newcomers
+  name: good first issue
+- color: ff7518
+  description: Pull request that should count toward Hacktoberfest participation
+  name: hacktoberfest-accepted
+- color: a2eeef
+  description: This issue or pull request will add or improve functionality, maintainability, or ease of use
+  name: improvement
+- color: fef2c0
+  description: This issue or pull request is not applicable, incorrect, or obsolete
+  name: invalid
+- color: f1d642
+  description: Pull requests that update JavaScript code
+  name: javascript
+- color: ce099a
+  description: This pull request is ready to merge during the next Lineage Kraken release
+  name: kraken 🐙
+- color: a4fc5d
+  description: This issue or pull request requires further information
+  name: need info
+- color: fcdb45
+  description: This pull request is awaiting an action or decision to move forward
+  name: on hold
+- color: 02a8ef
+  description: Pull requests that update Packer code
+  name: packer
+- color: 3772a4
+  description: Pull requests that update Python code
+  name: python
+- color: ef476c
+  description: This issue is a request for information or needs discussion
+  name: question
+- color: d73a4a
+  description: This issue or pull request addresses a security issue
+  name: security
+- color: 7b42bc
+  description: Pull requests that update Terraform code
+  name: terraform
+- color: 00008b
+  description: This issue or pull request adds or otherwise modifies test code
+  name: test
+- color: 2b6ebf
+  description: Pull requests that update TypeScript code
+  name: typescript
+- color: 1d76db
+  description: This issue or pull request pulls in upstream updates
+  name: upstream update
+- color: d4c5f9
+  description: This issue or pull request increments the version number
+  name: version bump
+- color: ffffff
+  description: This issue will not be incorporated
+  name: wontfix

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -68,6 +68,9 @@
 - color: ef476c
   description: This issue is a request for information or needs discussion
   name: question
+- color: 067790
+  description: Pull requests that update cyhy-runner jobs
+  name: cyhy-runner jobs
 - color: d73a4a
   description: This issue or pull request addresses a security issue
   name: security

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,93 @@
+---
+name: Label pull requests
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  label:
+    needs:
+      - diagnostics
+    permissions:
+      # Permissions required by actions/labeler
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - name: Apply suitable labels to a pull request
+        uses: actions/labeler@v6

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,94 @@
+---
+name: sync-labels
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  labeler:
+    needs:
+      - diagnostics
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+      # crazy-max/ghaction-github-labeler needs this to manage repository labels
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: actions/checkout@v5
+      - name: Sync repository labels
+        if: success()
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          # This is a hideous ternary equivalent so we only do a dry run unless
+          # this workflow is triggered by the develop branch.
+          dry-run: ${{ github.ref_name == 'develop' && 'false' || 'true' }}


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the label management and PR auto-labelling functionality that we use in our modern projects. I also made a couple of label updates that are project specific.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will help ensure that our usual labels are available in the project and also provide convenient auto-labelling of pull requests.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I eyeballed it. I also verified that the sync-label dry run would make the expected changes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
