### PR TITLE
Bugfix: Set PortScanDoc owner to UNKNOWN_OWNER if no HostDoc found

### DIFF
--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -757,7 +757,7 @@ class Commander(object):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.2")
     workingDir = os.path.join(os.getcwd(), args["<working-dir>"])
     if not os.path.exists(workingDir):
         print >>sys.stderr, 'Working directory "%s" does not exist.  Attempting to create...' % workingDir

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -99,7 +99,8 @@ class NmapImporter(object):
         if host_doc:
             ip_owner = host_doc.get("owner", UNKNOWN_OWNER)
         else:
-            ip_owner = None
+            self.__logger.warning("No HostDoc found for IP %s" % str(ip))
+            ip_owner = UNKNOWN_OWNER
         for (port, details) in parsed_host["ports"].items():
             if details["state"] != "open":  # only storing open ports
                 continue

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-commander",
-    version="1.0.1",
+    version="1.0.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This bugfix PR sets the owner of a PortScanDoc to the `UNKNOWN_OWNER` if no host doc is found for the scanned IP.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Without this PR, if a HostDoc is not found for the scanned IP, the commander attempts to create a PortScanDoc where the `owner` field is set to `None` and it results in an error like:

```
2025-10-31 18:10:02,458 CRITICAL cyhy_commander.commander - owner is required
2025-10-31 18:10:02,461 CRITICAL cyhy_commander.commander - Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/commander.py", line 460, in __process_queued_jobs
    self.__process_successful_job(job_path)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/commander.py", line 493, in __process_successful_job
    sink.handle(job_path)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/job_sink.py", line 33, in handle
    importer.process(nmap_output_file, target_file)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_importer.py", line 92, in process
    parse(f, self.handler)
  File "/usr/lib/python2.7/xml/sax/__init__.py", line 33, in parse
    parser.parse(source)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 111, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 220, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 339, in end_element
    self._cont_handler.endElement(name)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_handler.py", line 103, in endElement
    self.host_callback(self.currentHost)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_importer.py", line 226, in __portscan_host_callback
    has_at_least_one_open_port = self.__store_port_details(parsed_host)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_importer.py", line 147, in __store_port_details
    report.save()
  File "/usr/local/lib/python2.7/dist-packages/cyhy/db/database.py", line 201, in save
    raise e
RequireFieldError: owner is required
``` 

The change in this PR mirrors the behavior that we already do when creating HostScanDocs.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

All automated tests pass.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
