### PR TITLE
Add debug information to provide performance information and insight into Nmap job processing

### DIFF
--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -463,15 +463,18 @@ class Commander(object):
                 job_processing_function (callable): The function used to process a job.
 
             Returns:
-                The job path that was processed or None if the queue was empty.
+                A tuple whose first item is the job path that was processed or None if
+                the queue was empty, and whose second item is the duration it took to
+                process the job or determine the queue was empty.
             """
             job_path = None
+            job_processing_start = time.time()
 
             # check the successful jobs queue
             try:
                 job_path = target_job_queue.get(timeout=1)
             except Queue.Empty:
-                return job_path
+                return (job_path, time.time() - job_processing_start)
 
             try:
                 job_processing_function(job_path)
@@ -482,8 +485,8 @@ class Commander(object):
             # report task completion no matter what so the queue can be joined
             target_job_queue.task_done()
 
-            # return path of the job that was processed
-            return job_path
+            # return path of the job that was processed and how long it took to process
+            return (job_path, time.time() - job_processing_start)
 
         # run as long as the commander is processing jobs
         while self.__is_processing_jobs:
@@ -493,13 +496,19 @@ class Commander(object):
             )
 
             # process failed job if a successful job was not processed
-            if job_processing_results is None:
+            if job_processing_results[0] is None:
                 job_processing_results = process_job_from_queue(
                     self.__failed_job_queue, self.__process_failed_job
                 )
 
-            # sleep if both queues are empty
-            if job_processing_results is None:
+            if job_processing_results[0] is not None:
+                # output how long it took to process the job
+                self.__logger.debug(
+                    "Processed %s in %1.1f seconds"
+                    % (job_processing_results[0], job_processing_results[1])
+                )
+            else:
+                # sleep if both queues are empty
                 time.sleep(self.__job_processing_sleep_duration)
 
     def __process_successful_job(self, job_path):

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -205,7 +205,9 @@ class NmapImporter(object):
         details["latest"] = True
 
         ip = parsed_host["addr"]
-        self.__logger.debug("[%s] Storing OS details for IP %s" % (thread_name, str(ip)))
+        self.__logger.debug(
+            "[%s] Storing OS details for IP %s" % (thread_name, str(ip))
+        )
 
         host_doc = self.__db.HostDoc.get_by_ip(ip)
         if host_doc and host_doc.get("hostnames"):

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -249,10 +249,15 @@ class NmapImporter(object):
         thread_name = threading.current_thread().name
 
         # clear the latest flags compiled from __netscan_host_callback down
+        self.__logger.debug(
+            "[%s] Resetting latest flag for %d IPs"
+            % (thread_name, len(self.__ips_to_reset_latest))
+        )
         self.__db.HostScanDoc.reset_latest_flag_by_ip(self.__ips_to_reset_latest)
         self.__db.PortScanDoc.reset_latest_flag_by_ip(self.__ips_to_reset_latest)
         self.__db.VulnScanDoc.reset_latest_flag_by_ip(self.__ips_to_reset_latest)
         # tell the ticket manager to close what needs to be closed
+        self.__logger.debug("[%s] Closing tickets" % thread_name)
         self.__ticket_manager.close_tickets()
         self.__ticket_manager.clear_vuln_latest_flags()
 

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -90,6 +90,10 @@ class NmapImporter(object):
         with open(target_filename) as f:
             for ip_line in f:
                 self.__ticket_manager.ips.add(ip_line)
+        self.__logger.debug(
+            "[%s] Found %d targets in target file %s"
+            % (thread_name, len(self.__ticket_manager.ips), target_filename)
+        )
         # parse nmap data
         f = open(nmap_filename, "rb")
         # sometimes the first line of the nmap output is not xml
@@ -131,6 +135,10 @@ class NmapImporter(object):
             details["latest"] = True
 
             if host_doc and host_doc.get("hostnames"):
+                self.__logger.debug(
+                    "[%s] Creating PortScanDocs for %d hostnames"
+                    % (thread_name, len(host_doc["hostnames"]))
+                )
                 # Create a PortScanDoc for each hostname/owner combination
                 for h in host_doc["hostnames"]:
                     report = self.__db.PortScanDoc()
@@ -180,6 +188,9 @@ class NmapImporter(object):
         return has_at_least_one_open_port
 
     def __store_os_details(self, parsed_host):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         details = dict()
         if parsed_host.has_key("os"):
             util.copy_attrs(parsed_host["os"], details)
@@ -195,6 +206,10 @@ class NmapImporter(object):
         ip = parsed_host["addr"]
         host_doc = self.__db.HostDoc.get_by_ip(ip)
         if host_doc and host_doc.get("hostnames"):
+            self.__logger.debug(
+                "[%s] Creating HostScanDocs for %d hostnames"
+                % (thread_name, len(host_doc["hostnames"]))
+            )
             # Create a HostScanDoc for each hostname/owner combination
             for h in host_doc["hostnames"]:
                 host = self.__db.HostScanDoc()

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -205,7 +205,7 @@ class NmapImporter(object):
         details["latest"] = True
 
         ip = parsed_host["addr"]
-        self.__logger.debug("[%s] Storing OS details for IP %s", (thread_name, str(ip)))
+        self.__logger.debug("[%s] Storing OS details for IP %s" % (thread_name, str(ip)))
 
         host_doc = self.__db.HostDoc.get_by_ip(ip)
         if host_doc and host_doc.get("hostnames"):

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -117,6 +117,11 @@ class NmapImporter(object):
                 "[%s] No HostDoc found for IP %s" % (thread_name, str(ip))
             )
             ip_owner = UNKNOWN_OWNER
+
+        self.__logger.debug(
+            "[%s] Processing %d port results for IP %s"
+            % (thread_name, len(parsed_host["ports"]), str(ip))
+        )
         for (port, details) in parsed_host["ports"].items():
             if details["state"] != "open":  # only storing open ports
                 continue
@@ -135,10 +140,6 @@ class NmapImporter(object):
             details["latest"] = True
 
             if host_doc and host_doc.get("hostnames"):
-                self.__logger.debug(
-                    "[%s] Creating PortScanDocs for %d hostnames"
-                    % (thread_name, len(host_doc["hostnames"]))
-                )
                 # Create a PortScanDoc for each hostname/owner combination
                 for h in host_doc["hostnames"]:
                     report = self.__db.PortScanDoc()
@@ -204,11 +205,13 @@ class NmapImporter(object):
         details["latest"] = True
 
         ip = parsed_host["addr"]
+        self.__logger.debug("[%s] Storing OS details for IP %s", (thread_name, str(ip)))
+
         host_doc = self.__db.HostDoc.get_by_ip(ip)
         if host_doc and host_doc.get("hostnames"):
             self.__logger.debug(
-                "[%s] Creating HostScanDocs for %d hostnames"
-                % (thread_name, len(host_doc["hostnames"]))
+                "[%s] HostDoc for IP %s has %d hostnames"
+                % (thread_name, str(ip), len(host_doc["hostnames"]))
             )
             # Create a HostScanDoc for each hostname/owner combination
             for h in host_doc["hostnames"]:
@@ -274,6 +277,9 @@ class NmapImporter(object):
         # tell the ticket manager to close what needs to be closed
         self.__logger.debug("[%s] Closing tickets" % thread_name)
         self.__ticket_manager.close_tickets()
+        self.__logger.debug(
+            "[%s] Clear the latest flag for applicable VulnScanDocs" % thread_name
+        )
         self.__ticket_manager.clear_vuln_latest_flags()
 
         self.__logger.debug("[%s] Reached end of Nmap import" % thread_name)

--- a/cyhy_commander/nmap/nmap_importer.py
+++ b/cyhy_commander/nmap/nmap_importer.py
@@ -79,6 +79,12 @@ class NmapImporter(object):
 
     def process(self, nmap_filename, target_filename):
         """Imports nmap files created from netscans and portscans"""
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
+        self.__logger.debug(
+            "[%s] Starting processing of %s" % (thread_name, nmap_filename)
+        )
         # import target ips
         ips = netaddr.IPSet()
         with open(target_filename) as f:
@@ -239,6 +245,9 @@ class NmapImporter(object):
         self.__ch_db.transition_host(ip, has_open_ports=has_at_least_one_open_port)
 
     def __end_callback(self):
+        # Get the name of the current thread
+        thread_name = threading.current_thread().name
+
         # clear the latest flags compiled from __netscan_host_callback down
         self.__db.HostScanDoc.reset_latest_flag_by_ip(self.__ips_to_reset_latest)
         self.__db.PortScanDoc.reset_latest_flag_by_ip(self.__ips_to_reset_latest)
@@ -246,3 +255,5 @@ class NmapImporter(object):
         # tell the ticket manager to close what needs to be closed
         self.__ticket_manager.close_tickets()
         self.__ticket_manager.clear_vuln_latest_flags()
+
+        self.__logger.debug("[%s] Reached end of Nmap import" % thread_name)


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds logging to indicate how long a job took to process and insight into what the Nmap-based job (BASESCAN, NETSCAN1, NETSCAN2, PORTSCAN) is doing while being processed.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

While testing for #15 it became apparent that we wanted to know how long individual jobs took to process and that we wanted insight into where an Nmap-based job was in its processing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This has been working ok in @dav3r's test environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
