### PR TITLE
Process unfinished jobs at startup

### DIFF
--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -760,6 +760,20 @@ class Commander(object):
             ),
         )
 
+        # clear out retrieved but unprocessed work
+        self.__logger.debug("Process any leftover local jobs")
+        self.__queue_monitor_output_lock.release()
+        for target_dir, target_queue in (
+            (SUCCESS_DIR, self.__successful_job_queue),
+            (FAILED_DIR, self.__failed_job_queue),
+        ):
+            for job in os.listdir(target_dir):
+                target_queue.put(os.path.join(target_dir, job))
+        self.__successful_job_queue.join()
+        self.__failed_job_queue.join()
+        self.__queue_monitor_output_lock.acquire()
+        self.__logger.debug("Finished processing leftover jobs")
+
         # main work loop
         while self.__is_running:
             try:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a bit of logic to process any local jobs that are leftover from a previously running commander before moving into the main commander loop. This is done by simply loading them into the appropriate queue for the job processing threads to consume as they would freshly retrieved jobs.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If the commander crashes, is shutdown, or is killed while processing retrieved jobs they are currently left unprocessed. This results in retrieved work that is never fully processed and aside from slowly building up it will result in missed results.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in @dav3r's test environment and saw it process leftover work at startup.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
