### PR TITLE
Add a script to unstick stuck scans

### DIFF
--- a/cyhy_commander/commander.py
+++ b/cyhy_commander/commander.py
@@ -909,7 +909,7 @@ class Commander(object):
 
 
 def main():
-    args = docopt(__doc__, version="v1.1.0")
+    args = docopt(__doc__, version="v1.2.0")
     workingDir = os.path.join(os.getcwd(), args["<working-dir>"])
     if not os.path.exists(workingDir):
         print >>sys.stderr, 'Working directory "%s" does not exist.  Attempting to create...' % workingDir

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -77,16 +77,18 @@ def main():
     # Compute the stuck cutoff
     stuck_cutoff = compute_stuck_cutoff(days)
 
+    # Query for all hosts in the RUNNING state that have not been
+    # updated since stuck_cutoff
     logging.info(
         "Querying for all host docs in the %s state that have not been updated since %s.",
         STATUS.RUNNING,
         stuck_cutoff,
     )
-    hosts_cursor = db.hosts.find(
-        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
-    )
+    filter = {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
+    hosts_cursor = db.hosts.find(filter, {"owner": True})
 
-    logging.info("Gathering a list of all the owners associated with these host docs.")
+    # Gather a set of all owners associated with these host docs
+    logging.info("Gathering all the owners associated with these host docs.")
     owners = set()
     host_count = 0
     for host in hosts_cursor:
@@ -98,12 +100,13 @@ def main():
         host_count,
     )
 
+    # Update host docs with stuck scans
     logging.info(
         "Updating the host docs with stuck scans by setting their status to %s.",
         STATUS.WAITING,
     )
     result = db.hosts.update_many(
-        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
+        filter,
         {"$set": {"status": STATUS.WAITING}},
     )
     logging.info(
@@ -113,6 +116,7 @@ def main():
         STATUS.WAITING,
     )
 
+    # Sync tallies for affected owners
     logging.info("Syncing tallies for all affected owners.")
     for owner in owners:
         logging.debug("Getting tally doc for %s.", owner)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -109,3 +109,5 @@ def main():
                 "No existing tally doc found for %s.  Creating a new one.", owner
             )
             tally = db.TallyDoc()
+        logging.debug("Syncing tally for %s.", owner)
+        tally.sync(db)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -76,9 +76,15 @@ def main():
     logging.info(
         "Updating the host docs by setting their status to %s.", STATUS.WAITING
     )
-    db.hosts.updateMany(
+    result = db.hosts.update_many(
         {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
         {"$set": {"status": STATUS.WAITING}},
+    )
+    logging.info(
+        "Updated %d host documents from %s to %s.",
+        result.modified_count,
+        STATUS.RUNNING,
+        STATUS.WAITING,
     )
 
     logging.info("Syncing tallies for all affected owners.")
@@ -90,13 +96,3 @@ def main():
                 "No existing tally doc found for %s.  Creating a new one.", owner
             )
             tally = db.TallyDoc()
-    result = db.hosts.update_many(
-        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
-        {"$set": {"status": STATUS.WAITING}},
-    )
-    logging.info(
-        "Updated %d host documents from %s to %s.",
-        result.modified_count,
-        STATUS.RUNNING,
-        STATUS.WAITING,
-    )

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -27,16 +27,20 @@ from cyhy.db import database
 from cyhy.core.common import STATUS
 
 
-def main():
-    args = docopt(__doc__, version="v1.0.0")
-
-    # Set up logging
+def setup_logging(debug):
     log_level = logging.INFO
-    if args["--debug"]:
+    if debug:
         log_level = logging.DEBUG
     logging.basicConfig(
         format="%(asctime)-15s %(levelname)s %(message)s", level=log_level
     )
+
+
+def main():
+    args = docopt(__doc__, version="v1.0.0")
+
+    # Set up logging
+    setup_logging(args["--debug"])
 
     config = args["--config-file"]
     section = args["--section"]

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -44,6 +44,20 @@ def compute_stuck_cutoff(days):
     return date_today - timedelta(days=days)
 
 
+def sync_tallies(db, owners):
+    logging.info("Syncing tallies for all affected owners.")
+    for owner in owners:
+        logging.debug("Getting tally doc for %s.", owner)
+        tally = db.TallyDoc.get_by_owner(owner)
+        if tally is None:
+            logging.warning(
+                "No existing tally doc found for %s.  Creating a new one.", owner
+            )
+            tally = db.TallyDoc()
+        logging.debug("Syncing tally for %s.", owner)
+        tally.sync(db)
+
+
 def main():
     args = docopt(__doc__, version="v1.0.0")
 
@@ -117,14 +131,4 @@ def main():
     )
 
     # Sync tallies for affected owners
-    logging.info("Syncing tallies for all affected owners.")
-    for owner in owners:
-        logging.debug("Getting tally doc for %s.", owner)
-        tally = db.TallyDoc.get_by_owner(owner)
-        if tally is None:
-            logging.warning(
-                "No existing tally doc found for %s.  Creating a new one.", owner
-            )
-            tally = db.TallyDoc()
-        logging.debug("Syncing tally for %s.", owner)
-        tally.sync(db)
+    sync_tallies(db, owners)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -52,7 +52,9 @@ def main():
         return 1
 
     # Today's date at midnight UTC
-    date_today = datetime.combine(datetime.now(pytz.timezone("UTC")), time.min)
+    date_today = datetime.utcnow().replace(
+        hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
+    )
     stuck_cutoff = date_today - timedelta(days=int(args["--days"]))
 
     logging.info(

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -80,7 +80,11 @@ def main():
     for host in hosts_cursor:
         owners.add(host["owner"])
         host_count += 1
-    logging.info("%d unique owners found in %d host documents with stuck scans", len(owners), host_count)
+    logging.info(
+        "%d unique owners found in %d host documents with stuck scans",
+        len(owners),
+        host_count,
+    )
 
     logging.info(
         "Updating the host docs by setting their status to %s.", STATUS.WAITING

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -1,0 +1,81 @@
+"""Reset stuck scans back to the WAITING state.
+
+Usage:
+  cyhy-wd40 [options]
+  cyhy-wd40 (-h | --help)
+  cyhy-wd40 --version
+
+Options:
+  -d --debug                      Use verbose logging
+  -f FILE --config-file=FILE      Configuration file to use
+  -h --help                       Show this screen
+  -s SECTION --section=SECTION    Configuration section to use
+  -t DAYS --days=DAYS             Number of days a scan should go without an update before being considered stuck [default: 1]
+  --version                       Show version
+"""
+
+# Standard Python Libraries
+from datetime import datetime, time, timedelta
+import logging
+import pytz
+
+# Third-Party Libraries
+from docopt import docopt
+
+# cisagov Libraries
+from cyhy.db import database
+from cyhy.core.common import STATUS
+
+
+def main():
+    args = docopt(__doc__, version="v1.0.0")
+
+    # Set up logging
+    log_level = logging.WARNING
+    if args["--debug"]:
+        log_level = logging.DEBUG
+    logging.basicConfig(
+        format="%(asctime)-15s %(levelname)s %(message)s", level=log_level
+    )
+
+    config = args["--config-file"]
+    section = args["--section"]
+    try:
+        db = database.db_from_config(section, config)
+    except:
+        logging.critical(
+            "Unable to connect to the database server in section %s of %s", section, config,
+            exc_info=True,
+        )
+        return 1
+
+    # Today's date at midnight UTC
+    date_today = datetime.combine(
+        datetime.now(pytz.timezone("UTC")), time.min
+    )
+    stuck_cutoff = date_today - timedelta(days=int(args["--days"]))
+
+    logging.info("Querying for all host docs in the %s state that have not been updated since %s.", STATUS.RUNNING, stuck_cutoff)
+    hosts_cursor = db.hosts.find({"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}, no_cursor_timeout=True)
+
+    logging.info("Gathering a list of all the owners associated with these host docs.")
+    owners = set()
+    host_count = 0
+    for host in hosts_cursor:
+        owners.add(host["owner"])
+        host_count += 1
+    logging.info("%d unique owners found in %d host documents", len(owners), host_count)
+
+    logging.info("Updating the host docs by setting their status to %s.", STATUS.WAITING)
+    db.hosts.updateMany({"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}, {"$set": {"status": STATUS.WAITING}})
+
+    logging.info("Syncing tallies for all affected owners.")
+    for owner in owners:
+        logging.debug("Getting tally doc for %s.", owner)
+        tally = db.TallyDoc.get_by_owner(owner)
+        if tally is None:
+            logging.warning("No existing tally doc found for %s.  Creating a new one.", owner)
+            tally = db.TallyDoc()
+            tally["_id"] = owner
+        logging.debug("Syncing tally for %s.", owner)
+        tally.sync(db)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -1,5 +1,9 @@
 """Reset stuck scans back to the WAITING state.
 
+Stuck scans are defined as scans that are in the RUNNING state but
+have had no updates in a specified number of days. The number of days
+can be specified in the script's CLI and defaults to 1.
+
 Usage:
   cyhy-wd40 [options]
   cyhy-wd40 (-h | --help)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -71,8 +71,7 @@ def main():
         stuck_cutoff,
     )
     hosts_cursor = db.hosts.find(
-        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
-        no_cursor_timeout=True,
+        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
     )
 
     logging.info("Gathering a list of all the owners associated with these host docs.")

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -55,7 +55,15 @@ def main():
     date_today = datetime.utcnow().replace(
         hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
     )
-    stuck_cutoff = date_today - timedelta(days=int(args["--days"]))
+    try:
+        days = int(args["--days"])
+    except (TypeError, ValueError):
+        logging.critical(
+            "Invalid value for --days (%r); it must be an integer.",
+            args["--days"],
+        )
+        return 1
+    stuck_cutoff = date_today - timedelta(days=days)
 
     logging.info(
         "Querying for all host docs in the %s state that have not been updated since %s.",

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -37,11 +37,9 @@ def setup_logging(debug):
 
 
 def compute_stuck_cutoff(days):
-    # Today's date at midnight UTC
-    date_today = datetime.utcnow().replace(
-        hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
-    )
-    return date_today - timedelta(days=days)
+    # Current time in UTC
+    now_utc = datetime.utcnow().replace(tzinfo=pytz.timezone("UTC"))
+    return now_utc - timedelta(days=days)
 
 
 def sync_tallies(db, owners):

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -88,7 +88,10 @@ def main():
         return 1
     else:
         if days < 0:
-            logging.critical("Invalid value for --days (%d); it must be a positive, nonzero integer.", days)
+            logging.critical(
+                "Invalid value for --days (%d); it must be a positive, nonzero integer.",
+                days,
+            )
             return 1
 
     # Compute the stuck cutoff

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -105,7 +105,7 @@ def main():
         stuck_cutoff,
     )
     filter = {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
-    hosts_cursor = db.hosts.find(filter, {"owner": True})
+    hosts_cursor = db.HostDoc.collection.find(filter, {"owner": True})
 
     # Gather a set of all owners associated with these host docs
     logging.info("Gathering all the owners associated with these host docs.")
@@ -125,7 +125,7 @@ def main():
         "Updating the host docs with stuck scans by setting their status to %s.",
         STATUS.WAITING,
     )
-    result = db.hosts.update_many(
+    result = db.HostDoc.collection.update_many(
         filter,
         {"$set": {"status": STATUS.WAITING}},
     )

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -15,7 +15,7 @@ Options:
 """
 
 # Standard Python Libraries
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 import logging
 import pytz
 
@@ -42,7 +42,7 @@ def main():
     section = args["--section"]
     try:
         db = database.db_from_config(section, config)
-    except:
+    except Exception:
         logging.critical(
             "Unable to connect to the database server in section %s of %s",
             section,

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -78,7 +78,8 @@ def main():
         )
         return 1
 
-    # Ensure that the --days argument is indeed an integer
+    # Ensure that the --days argument is indeed a positive, nonzero
+    # integer
     try:
         days = int(args["--days"])
     except (TypeError, ValueError):
@@ -87,6 +88,10 @@ def main():
             args["--days"],
         )
         return 1
+    else:
+        if days < 0:
+            logging.critical("Invalid value for --days (%d); it must be a positive, nonzero integer.", days)
+            return 1
 
     # Compute the stuck cutoff
     stuck_cutoff = compute_stuck_cutoff(days)

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -87,7 +87,8 @@ def main():
     )
 
     logging.info(
-        "Updating the host docs with stuck scans by setting their status to %s.", STATUS.WAITING
+        "Updating the host docs with stuck scans by setting their status to %s.",
+        STATUS.WAITING,
     )
     result = db.hosts.update_many(
         {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -87,7 +87,7 @@ def main():
     )
 
     logging.info(
-        "Updating the host docs by setting their status to %s.", STATUS.WAITING
+        "Updating the host docs with stuck scans by setting their status to %s.", STATUS.WAITING
     )
     result = db.hosts.update_many(
         {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -36,12 +36,21 @@ def setup_logging(debug):
     )
 
 
+def compute_stuck_cutoff(days):
+    # Today's date at midnight UTC
+    date_today = datetime.utcnow().replace(
+        hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
+    )
+    return date_today - timedelta(days=days)
+
+
 def main():
     args = docopt(__doc__, version="v1.0.0")
 
     # Set up logging
     setup_logging(args["--debug"])
 
+    # Connect to database
     config = args["--config-file"]
     section = args["--section"]
     try:
@@ -55,10 +64,7 @@ def main():
         )
         return 1
 
-    # Today's date at midnight UTC
-    date_today = datetime.utcnow().replace(
-        hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
-    )
+    # Ensure that the --days argument is indeed an integer
     try:
         days = int(args["--days"])
     except (TypeError, ValueError):
@@ -67,7 +73,9 @@ def main():
             args["--days"],
         )
         return 1
-    stuck_cutoff = date_today - timedelta(days=days)
+
+    # Compute the stuck cutoff
+    stuck_cutoff = compute_stuck_cutoff(days)
 
     logging.info(
         "Querying for all host docs in the %s state that have not been updated since %s.",

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -76,6 +76,13 @@ def main():
         if tally is None:
             logging.warning("No existing tally doc found for %s.  Creating a new one.", owner)
             tally = db.TallyDoc()
-            tally["_id"] = owner
-        logging.debug("Syncing tally for %s.", owner)
-        tally.sync(db)
+    result = db.hosts.update_many(
+        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
+        {"$set": {"status": STATUS.WAITING}},
+    )
+    logging.info(
+        "Updated %d host documents from %s to %s.",
+        result.modified_count,
+        STATUS.RUNNING,
+        STATUS.WAITING,
+    )

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -110,8 +110,8 @@ def main():
         STATUS.RUNNING,
         stuck_cutoff,
     )
-    filter = {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
-    hosts_cursor = db.HostDoc.collection.find(filter, {"owner": True})
+    query = {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}
+    hosts_cursor = db.HostDoc.collection.find(query, {"owner": True})
 
     # Gather a set of all owners associated with these host docs
     logging.info("Gathering all the owners associated with these host docs.")
@@ -132,7 +132,7 @@ def main():
         STATUS.WAITING,
     )
     result = db.HostDoc.collection.update_many(
-        filter,
+        query,
         {"$set": {"status": STATUS.WAITING}},
     )
     logging.info(

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -56,7 +56,8 @@ def sync_tallies(db, owners):
             tally.sync(db)
         else:
             logging.warning(
-                "No existing tally doc found for %s.  You should verify that this is intentional, e.g., because the org has been retired.", owner
+                "No existing tally doc found for %s.  You should verify that this is intentional, e.g., because the org has been retired.",
+                owner,
             )
             continue
 

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -80,7 +80,7 @@ def main():
     for host in hosts_cursor:
         owners.add(host["owner"])
         host_count += 1
-    logging.info("%d unique owners found in %d host documents", len(owners), host_count)
+    logging.info("%d unique owners found in %d host documents with stuck scans", len(owners), host_count)
 
     logging.info(
         "Updating the host docs by setting their status to %s.", STATUS.WAITING

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -31,7 +31,7 @@ def main():
     args = docopt(__doc__, version="v1.0.0")
 
     # Set up logging
-    log_level = logging.WARNING
+    log_level = logging.INFO
     if args["--debug"]:
         log_level = logging.DEBUG
     logging.basicConfig(

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -2,7 +2,7 @@
 
 Stuck scans are defined as scans that are in the RUNNING state but
 have had no updates in a specified number of days. The number of days
-can be specified in the script's CLI and defaults to 1.
+can be specified and defaults to 1.
 
 Usage:
   cyhy-wd40 [options]

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -51,13 +51,14 @@ def sync_tallies(db, owners):
     for owner in owners:
         logging.debug("Getting tally doc for %s.", owner)
         tally = db.TallyDoc.get_by_owner(owner)
-        if tally is None:
+        if tally is not None:
+            logging.debug("Syncing tally for %s.", owner)
+            tally.sync(db)
+        else:
             logging.warning(
-                "No existing tally doc found for %s.  Creating a new one.", owner
+                "No existing tally doc found for %s.  You should verify that this is intentional, e.g., because the org has been retired.", owner
             )
-            tally = db.TallyDoc()
-        logging.debug("Syncing tally for %s.", owner)
-        tally.sync(db)
+            continue
 
 
 def main():

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -44,19 +44,26 @@ def main():
         db = database.db_from_config(section, config)
     except:
         logging.critical(
-            "Unable to connect to the database server in section %s of %s", section, config,
+            "Unable to connect to the database server in section %s of %s",
+            section,
+            config,
             exc_info=True,
         )
         return 1
 
     # Today's date at midnight UTC
-    date_today = datetime.combine(
-        datetime.now(pytz.timezone("UTC")), time.min
-    )
+    date_today = datetime.combine(datetime.now(pytz.timezone("UTC")), time.min)
     stuck_cutoff = date_today - timedelta(days=int(args["--days"]))
 
-    logging.info("Querying for all host docs in the %s state that have not been updated since %s.", STATUS.RUNNING, stuck_cutoff)
-    hosts_cursor = db.hosts.find({"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}, no_cursor_timeout=True)
+    logging.info(
+        "Querying for all host docs in the %s state that have not been updated since %s.",
+        STATUS.RUNNING,
+        stuck_cutoff,
+    )
+    hosts_cursor = db.hosts.find(
+        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
+        no_cursor_timeout=True,
+    )
 
     logging.info("Gathering a list of all the owners associated with these host docs.")
     owners = set()
@@ -66,15 +73,22 @@ def main():
         host_count += 1
     logging.info("%d unique owners found in %d host documents", len(owners), host_count)
 
-    logging.info("Updating the host docs by setting their status to %s.", STATUS.WAITING)
-    db.hosts.updateMany({"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}}, {"$set": {"status": STATUS.WAITING}})
+    logging.info(
+        "Updating the host docs by setting their status to %s.", STATUS.WAITING
+    )
+    db.hosts.updateMany(
+        {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},
+        {"$set": {"status": STATUS.WAITING}},
+    )
 
     logging.info("Syncing tallies for all affected owners.")
     for owner in owners:
         logging.debug("Getting tally doc for %s.", owner)
         tally = db.TallyDoc.get_by_owner(owner)
         if tally is None:
-            logging.warning("No existing tally doc found for %s.  Creating a new one.", owner)
+            logging.warning(
+                "No existing tally doc found for %s.  Creating a new one.", owner
+            )
             tally = db.TallyDoc()
     result = db.hosts.update_many(
         {"status": STATUS.RUNNING, "last_change": {"$lt": stuck_cutoff}},

--- a/cyhy_commander/wd40.py
+++ b/cyhy_commander/wd40.py
@@ -21,10 +21,10 @@ Options:
 # Standard Python Libraries
 from datetime import datetime, timedelta
 import logging
-import pytz
 
 # Third-Party Libraries
 from docopt import docopt
+import pytz
 
 # cisagov Libraries
 from cyhy.db import database

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         "Fabric >= 1.8.3, < 2.0.0",
         "lockfile >= 0.9.1",
         "python-daemon == 2.3.0",
-        "pytz >= 2026.1.post1"
+        "pytz >= 2026.1.post1",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         "Fabric >= 1.8.3, < 2.0.0",
         "lockfile >= 0.9.1",
         "python-daemon == 2.3.0",
-        "pytz >= 2026.1.post1",
+        "pytz",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "console_scripts": [
             "cyhy-commander=cyhy_commander.commander:main",
             "cyhy-nessus-import=cyhy_commander.nessus_import_tool:main",
+            "cyhy-wd40=cyhy_commander.wd40:main",
         ]
     },
     # license='LICENSE.txt',

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
         "docopt >= 0.6.2",
         "python-daemon == 2.3.0",
         "lockfile >= 0.9.1",
+        "pytz >= 2026.1.post1"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-commander",
-    version="1.1.0",
+    version="1.2.0",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup(
     # long_description=open('README.txt').read(),
     install_requires=[
         "cyhy-core >= 1.0.0",
-        "Fabric >= 1.8.3, < 2.0.0",
         "docopt >= 0.6.2",
-        "python-daemon == 2.3.0",
+        "Fabric >= 1.8.3, < 2.0.0",
         "lockfile >= 0.9.1",
+        "python-daemon == 2.3.0",
         "pytz >= 2026.1.post1"
     ],
 )


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a script to this Python project to unstick stuck scans.

Stuck scans are defined as scans that are in the `RUNNING` state but have had no updates in a specified number of days.  The number of days can be specified in the script's CLI and defaults to `1`.

See also cisagov/ansible-role-cyhy-commander#101.

## 💭 Motivation and context ##

Stuck scans are a thing and we have been asked to create an automated solution.  That solution consists of running this new script daily on the CyHy `database1` instance.

## 🧪 Testing ##

I have run the script on `database1` with the two lines that actually write to the database commented out and verified from the logging output that it appears to be running as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
